### PR TITLE
add experimental setWireTimeout

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -17,12 +17,12 @@ compile:
   # Choosing to run compilation tests on 2 different Arduino platforms
   platforms:
     - uno
-    # - due
-    # - zero
-    # - leonardo
+    - due
+    - zero
+    - leonardo
     - m4
     - esp32
     - esp8266
-    # - mega2560
+    - mega2560
     - rpipico
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [0.1.4] - 2022-10-30
+- update GitHub actions
+- update license 2023
+- add experimental **setWireTimeout()**
+- minor edit examples
+
+
 ## [0.1.3] - 2022-10-30
 - Add RP2040 support to build-CI.
 - Add CHANGELOG.md
 - extend example
-
 
 ## [0.1.2] - 2022-08-30
 - elaborate up to useful version

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -167,17 +167,21 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 }
 
 
-bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
+bool I2C_SCANNER::setWireTimeout(uint32_t timeOut)
 {
-  _timeOut = timeOut;
-  _wire->setWireTimeOut(timeOut);
-  return true;
+  if (_timeout != timeOut)
+  {
+    _timeout = timeOut;
+    _wire->setWireTimeout(timeOut);
+    return true;
+  }
+  return false;
 }
 
 
-uint32_t I2C_SCANNER::getWireTimeOut()
+uint32_t I2C_SCANNER::getWireTimeout()
 {
-  return _timeOut;
+  return _timeout;
 }
 
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -170,7 +170,7 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
 {
   _timeOut = timeOut;
-  //  _wire->setWireTimeOut(timeOut);
+  _wire->setWireTimeOut(timeOut);
   return true;
 }
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -171,6 +171,7 @@ bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
 {
   _timeOut = timeOut;
   _wire->setWireTimeOut(timeOut);
+  return true;
 }
 
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -167,14 +167,14 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 }
 
 
-bool I2C_SCANNER::setTimeOut(uint32_t timeOut)
+bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
 {
   _timeOut = timeOut;
-  _wire->setTimeOut(timeOut);
+  _wire->setWireTimeOut(timeOut);
 }
 
 
-uint32_t getTimeOut()
+uint32_t getWireTimeOut()
 {
   return _timeOut;
 }

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -169,15 +169,15 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 
 bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
 {
-  _timeOut = timeOut;
-  _wire->setWireTimeOut(timeOut);
+  _wireTimeOut = timeOut;
+  //  _wire->setWireTimeOut(timeOut);
   return true;
 }
 
 
 uint32_t getWireTimeOut()
 {
-  return _timeOut;
+  return _wireTimeOut;
 }
 
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -169,15 +169,15 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 
 bool I2C_SCANNER::setWireTimeOut(uint32_t timeOut)
 {
-  _wireTimeOut = timeOut;
+  _timeOut = timeOut;
   //  _wire->setWireTimeOut(timeOut);
   return true;
 }
 
 
-uint32_t getWireTimeOut()
+uint32_t I2C_SCANNER::getWireTimeOut()
 {
-  return _wireTimeOut;
+  return _timeOut;
 }
 
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -1,11 +1,9 @@
 //
 //    FILE: I2C_SCANNER.cpp
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
+// VERSION: 0.1.4
 //    DATE: 2022-08-29
 // PURPOSE: I2C scanner class
-//
-// HISTORY: see changelog.md
 
 
 #include "I2C_SCANNER.h"
@@ -88,6 +86,7 @@ TwoWire* I2C_SCANNER::getWire()
   return _wire;
 }
 
+
 //
 //  RESET
 //
@@ -167,6 +166,20 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
   return cnt;
 }
 
+
+bool I2C_SCANNER::setTimeOut(uint32_t timeOut)
+{
+  _timeOut = timeOut;
+  _wire->setTimeOut(timeOut);
+}
+
+
+uint32_t getTimeOut()
+{
+  return _timeOut;
+}
+
+
 ////////////////////////////////////////////////////
 //
 //  PRIVATE
@@ -174,6 +187,7 @@ uint8_t I2C_SCANNER::count(uint8_t start, uint8_t end)
 int I2C_SCANNER::_init()
 {
   Wire.begin();
+
   _wirePortCount = 1;
 #if defined WIRE_IMPLEMENT_WIRE1 || WIRE_INTERFACES_COUNT > 1
   Wire1.begin();
@@ -199,5 +213,5 @@ int I2C_SCANNER::_init()
 }
 
 
-// -- END OF FILE --
+//  -- END OF FILE --
 

--- a/I2C_SCANNER.cpp
+++ b/I2C_SCANNER.cpp
@@ -172,7 +172,8 @@ bool I2C_SCANNER::setWireTimeout(uint32_t timeOut)
   if (_timeout != timeOut)
   {
     _timeout = timeOut;
-    _wire->setWireTimeout(timeOut);
+    //  not all platforms support this.
+    //  _wire->setWireTimeout(timeOut);
     return true;
   }
   return false;

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -2,15 +2,15 @@
 //
 //    FILE: I2C_SCANNER.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.3
+// VERSION: 0.1.4
 //    DATE: 2022-08-29
 // PURPOSE: I2C scanner class
-//
+
 
 #include "Arduino.h"
 #include "Wire.h"
 
-#define I2C_SCANNER_LIB_VERSION        (F("0.1.3"))
+#define I2C_SCANNER_LIB_VERSION        (F("0.1.4"))
 
 
 class I2C_SCANNER
@@ -41,17 +41,22 @@ public:
   uint32_t getClock();
 #endif
 
-
   //  SCANNING FUNCTIONS
   bool     ping(uint8_t address);
   int      diag(uint8_t address);
   int32_t  pingTime(uint8_t address);
   uint8_t  count(uint8_t start = 0, uint8_t end = 127);
 
+
+  bool     setTimeOut(uint32_t timeOut);
+  uint32_t getTimeOut();
+
 private:
   int      _init();
   int      _wirePortCount;
   TwoWire* _wire;
+  
+  uint32_t _timeOut = 0;
 };
 
 

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -48,8 +48,8 @@ public:
   uint8_t  count(uint8_t start = 0, uint8_t end = 127);
 
 
-  bool     setTimeOut(uint32_t timeOut);
-  uint32_t getTimeOut();
+  bool     setWireTimeOut(uint32_t timeOut);
+  uint32_t getWireTimeOut();
 
 private:
   int      _init();

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -56,7 +56,7 @@ private:
   int      _wirePortCount;
   TwoWire* _wire;
   
-  uint32_t _timeOut = 0;
+  uint32_t _wireTimeOut = 0;
 };
 
 

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -48,15 +48,15 @@ public:
   uint8_t  count(uint8_t start = 0, uint8_t end = 127);
 
 
-  bool     setWireTimeOut(uint32_t timeOut);
-  uint32_t getWireTimeOut();
+  bool     setWireTimeout(uint32_t timeOut);
+  uint32_t getWireTimeout();
 
 private:
   int      _init();
   int      _wirePortCount;
   TwoWire* _wire;
   
-  uint32_t _timeOut = 0;
+  uint32_t _timeout = 0;
 };
 
 

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -56,7 +56,7 @@ private:
   int      _wirePortCount;
   TwoWire* _wire;
   
-  uint32_t _wireTimeOut = 0;
+  uint32_t _timeOut = 0;
 };
 
 

--- a/I2C_SCANNER.h
+++ b/I2C_SCANNER.h
@@ -47,7 +47,9 @@ public:
   int32_t  pingTime(uint8_t address);
   uint8_t  count(uint8_t start = 0, uint8_t end = 127);
 
-
+  //  experimental.
+  //  not all platforms support this function.
+  //  patch .cpp file to get this working for your platform.
   bool     setWireTimeout(uint32_t timeOut);
   uint32_t getWireTimeout();
 

--- a/examples/I2C_scanner_count/I2C_scanner_count.ino
+++ b/examples/I2C_scanner_count/I2C_scanner_count.ino
@@ -8,6 +8,7 @@
 
 I2C_SCANNER scanner;
 
+
 void setup()
 {
   Serial.begin(115200);
@@ -36,8 +37,10 @@ void setup()
   Serial.println("\ndone...");
 }
 
+
 void loop()
 {
 }
 
-// -- END OF FILE --
+
+//  -- END OF FILE --

--- a/examples/I2C_scanner_getWirePortCount/I2C_scanner_getWirePortCount.ino
+++ b/examples/I2C_scanner_getWirePortCount/I2C_scanner_getWirePortCount.ino
@@ -8,6 +8,7 @@
 
 I2C_SCANNER scanner;
 
+
 void setup()
 {
   Serial.begin(115200);
@@ -64,4 +65,6 @@ int simpleScan()
   Serial.println();
   return count;
 }
-// -- END OF FILE --
+
+
+//  -- END OF FILE --

--- a/examples/I2C_scanner_minimal/I2C_scanner_minimal.ino
+++ b/examples/I2C_scanner_minimal/I2C_scanner_minimal.ino
@@ -8,6 +8,7 @@
 
 I2C_SCANNER scanner;
 
+
 void setup()
 {
   Serial.begin(115200);
@@ -27,9 +28,11 @@ void setup()
   }
 }
 
+
 void loop()
 {
 }
 
-// -- END OF FILE --
+
+//  -- END OF FILE --
 

--- a/examples/I2C_scanner_simple/I2C_scanner_simple.ino
+++ b/examples/I2C_scanner_simple/I2C_scanner_simple.ino
@@ -8,6 +8,7 @@
 
 I2C_SCANNER scanner;
 
+
 void setup()
 {
   Serial.begin(115200);
@@ -36,8 +37,11 @@ void setup()
   Serial.println();
 }
 
+
 void loop()
 {
 }
 
-// -- END OF FILE --
+
+//  -- END OF FILE --
+

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/I2C_SCANNER.git"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "MIT",
   "frameworks": "arduino",
   "platforms": "*",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=I2C_SCANNER
-version=0.1.3
+version=0.1.4
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Arduino class to implement an I2C scanner.


### PR DESCRIPTION
- **setWireTimeout()** is not supported by all platforms including build-ci.
- might be useful in more "enhanced" scanners that want to read data from specific devices
